### PR TITLE
Filter view changes, export changes

### DIFF
--- a/css/alignViewBB.css
+++ b/css/alignViewBB.css
@@ -163,11 +163,3 @@ DIV.alignSettings {
 	border-right: 1px solid #aaa;
 	margin-right: 0.5em;
 }
-
-.alignView .topRule {
-	margin-top: 0.5em;
-	/*border-top: 1px solid #aaa;*/
-	font-size: 0.75em;
-	color: #668;
-	line-height: 1.4em;
-}

--- a/css/filter.css
+++ b/css/filter.css
@@ -3,13 +3,26 @@
 }
 
 .filterControlGroup {
-	vertical-align:top;
+	position: relative;
+	vertical-align: top;
     display: inline-block;
     padding: 0 0.35em 0 0;
 	border-right: 1px solid #bbb;
 	margin: auto 0.35em auto 0;
     height: 65px;
 }
+
+/*
+.filterControlGroup:after {
+	position: absolute;
+	top: 0.25em;
+	right: -0.25em;
+	font-size: 3em;
+	color: #bbb;
+	content: '>';
+	transform: scale(0.7, 3);
+}
+*/
 
 /*
 .filterControlGroup > div {
@@ -40,13 +53,13 @@ div.filterControlGroup label:hover {
 }
 
 
-div.textFilters, div.toggles, div.scoreSlider > div {
+div.textFilters, div.toggles, div.scoreSlider > div, div.navNumberFilterDiv {
     display: inline-block;
     vertical-align: top;
 }
 
 
-.textFilters span:after, .toggles span:after, .scoreSlider span:after {
+.textFilters span:after, .toggles span:after, .scoreSlider span:after, .navNumberFilterDiv span:after {
     content: ' ';
     display: block;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -753,3 +753,10 @@ input {
 }
 
 sup {font-size:xx-small; vertical-align:super;}
+
+.smallHeading {
+	margin-top: 0.5em;
+	font-size: 0.75em;
+	color: #668;
+	line-height: 1.4em;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -760,3 +760,9 @@ sup {font-size:xx-small; vertical-align:super;}
 	color: #668;
 	line-height: 1.4em;
 }
+
+.btn-tight {
+	margin: 0;
+	padding: 2px 2px;
+	border: 1px solid grey;
+}

--- a/js/PDBFileChooser.js
+++ b/js/PDBFileChooser.js
@@ -72,6 +72,8 @@ CLMSUI.PDBFileChooserBB = CLMSUI.utils.BaseFrameView.extend ({
 		var queryBox = toolbar.append("div")
 			.attr ("class", "verticalFlexContainer queryBox")
 		;
+		
+		queryBox.append("p").attr("class", "smallHeading").text("PDB Query Services");
 
 		queryBox.append("button")
 			.attr ("class", "pdbWindowButton btn btn-1 btn-1a")

--- a/js/alignViewBB3.js
+++ b/js/alignViewBB3.js
@@ -19,7 +19,7 @@
             var topElem = d3.select(this.el);
             var modelViewID = topElem.attr("id") + "IndView";
             var holdingDiv = topElem.append("DIV").attr("class", "alignView");
-            var template = _.template ("<P><span><%= headerText %></span><span class='alignSortWidget'></span></P><DIV class='checkHolder'></DIV><DIV id='<%= alignModelViewID %>'></DIV><DIV><P class='topRule'>Per Protein Settings</P><DIV id='<%= alignControlID %>'></DIV></DIV><DIV><P class='topRule'></P><DIV id='<%= alignControlID2 %>'></DIV></DIV>");
+            var template = _.template ("<P><span><%= headerText %></span><span class='alignSortWidget'></span></P><DIV class='checkHolder'></DIV><DIV id='<%= alignModelViewID %>'></DIV><DIV><P class='smallHeading'>Per Protein Settings</P><DIV id='<%= alignControlID %>'></DIV></DIV><DIV><DIV id='<%= alignControlID2 %>'></DIV></DIV>");
             holdingDiv.html (template ({
                 headerText: "Select Protein Name in Tab for Details",
                 alignModelViewID: modelViewID,

--- a/js/distogramViewBB.js
+++ b/js/distogramViewBB.js
@@ -305,7 +305,7 @@ CLMSUI.DistogramBB = CLMSUI.utils.BaseFrameView.extend({
             selectList: ["X"],
             optionList: options,
 			keepOldOptions: keepOld || false,
-            selectLabelFunc: function () { return "Plot This Data Along Axis ►"; },
+            selectLabelFunc: function (d) { return "Plot This Data On The "+d+" Axis ►"; },
             optionLabelFunc: function (d) { return d.label; },
 			optionValueFunc: function (d) { return d.id; },
             changeFunc: function () { self.render(); },

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -119,14 +119,29 @@ function mostReadableId (protein) {
 
 
 function getMatchesCSV () {
-    var csv = '"Id","Protein1","SeqPos1","PepPos1","PepSeq1","LinkPos1","Protein2","SeqPos2","PepPos2","PepSeq2","LinkPos2","Score","Charge","ExpMz","ExpMass","CalcMz","CalcMass","MassError","AutoValidated","Validated","Search","RawFileName","ScanNumber","ScanIndex","CrossLinkerModMass","FragmentTolerance","IonTypes","3D Distance","From Chain","To Chain","PDB SeqPos 1","PDB SeqPos 2"\r\n';
+    var csv = '"Id","Protein1","SeqPos1","PepPos1","PepSeq1","LinkPos1","Protein2","SeqPos2","PepPos2","PepSeq2","LinkPos2","Score","Charge","ExpMz","ExpMass","CalcMz","CalcMass","MassError","AutoValidated","Validated","Search","RawFileName","ScanNumber","ScanIndex","CrossLinkerModMass","FragmentTolerance","IonTypes","Decoy1","Decoy2","3D Distance","From Chain","To Chain","PDB SeqPos 1","PDB SeqPos 2"\r\n';
     var clmsModel = CLMSUI.compositeModelInst.get("clmsModel");
-    var matches = clmsModel.get("matches");
-    var matchCount = matches.length;
-    var proteinMatchFunc = clmsModel.isMatchingProteinPairFromIDs.bind(clmsModel);
-    var filterModel = CLMSUI.compositeModelInst.get("filterModel");
 	var distance2dp = d3.format(".2f");
+	
+	var crossLinks = CLMSUI.compositeModelInst.getFilteredCrossLinks ("all");
+	var matchMap = d3.map();
+	
+	// do it like this so ambiguous matches (belonging to >1 crosslink) aren't repeated
+	crossLinks.forEach (function (crossLink) {
+		crossLink.filteredMatches_pp.forEach (function (match) {
+			matchMap.set (match.match.id, match.match);
+		})
+	});
+	//console.log ("CL", crossLinks, matchMap);
 
+	/*
+	var count = 0;
+	var matchCount = matches.length;
+	var matches = clmsModel.get("matches");
+
+    var filterModel = CLMSUI.compositeModelInst.get("filterModel");
+    var proteinMatchFunc = clmsModel.isMatchingProteinPairFromIDs.bind(clmsModel);
+	
     for (var m = 0; m < matchCount; ++m){
 		var match = matches[m];
         var result;
@@ -139,11 +154,19 @@ function getMatchesCSV () {
 						&& filterModel.navigationFilter(match);
 		}
         if (result === true){
+			count++;
+		*/
+			
+	matchMap.values().forEach (function (match) {
+			var peptides1 = match.matchedPeptides[0];
 			var peptides2 = match.matchedPeptides[1];
             var pp1 = CLMSUI.utils.pepPosConcat(match, 0);
             var pp2 = CLMSUI.utils.pepPosConcat(match, 1);
-			var lp1 = match.matchedPeptides[0].pos.map (function (v) { return v + match.linkPos1 - 1; }).join(", ");
+			var lp1 = peptides1.pos.map (function (v) { return v + match.linkPos1 - 1; }).join(", ");
 			var lp2 = peptides2 ? peptides2.pos.map (function (v) { return v + match.linkPos2 - 1; }).join(", ") : "";
+			
+			var decoy1 = clmsModel.get("participants").get(peptides1.prt[0]).is_decoy;
+			var decoy2 = peptides2 ? clmsModel.get("participants").get(peptides2.prt[0]).is_decoy : "";
 			
 			// Work out distances for this match - ambiguous matches will have >1 crosslink
 			var crossLinks = match.crossLinks;
@@ -154,20 +177,17 @@ function getMatchesCSV () {
 			var distancesTransposed = d3.transpose (distances2DArr); // transpose so distance data now grouped in array by field (distance, tores, etc)
 			var distancesJoined = distancesTransposed.map (function (arr) { return arr.join(", "); });
 			
-            csv += '"' + match.id + '","' + CLMSUI.utils.proteinConcat(match, 0, CLMSUI.compositeModelInst.get("clmsModel"))
-                + '","' + lp1 + '","' + pp1 + '","'
-                + match.matchedPeptides[0].seq_mods + '","' + match.linkPos1 + '","'
-                + (peptides2 ? CLMSUI.utils.proteinConcat(match, 1, CLMSUI.compositeModelInst.get("clmsModel")) : "")
-                + '","' + lp2 + '","' + pp2 + '","'
-                + (peptides2 ? peptides2.seq_mods : "") + '","' + match.linkPos2 + '","'
-                + match.score() + '","' + match.precursorCharge + '","'  + match.expMZ() + '","' + match.expMass() + '","'
-                + match.calcMZ() + '","' + match.calcMass() + '","' + match.massError() + '","'
-                + match.autovalidated + '","' + match.validated + '","'
-                + match.searchId + '","' + match.runName() + '","' + match.scanNumber + '","' + match.scanIndex + '","'
-                + match.crossLinkerModMass() + '","' + match.fragmentToleranceString() + '","' + match.ionTypesString() +'","'
-				+ distancesJoined.join('","') + '"\r\n';
+			var data = [
+				match.id, CLMSUI.utils.proteinConcat(match, 0, clmsModel), lp1, pp1, peptides1.seq_mods, match.linkPos1, (peptides2 ? CLMSUI.utils.proteinConcat(match, 1, clmsModel) : ""), lp2, pp2, (peptides2 ? peptides2.seq_mods : ""), match.linkPos2, match.score(), match.precursorCharge, match.expMZ(), match.expMass(), match.calcMZ(), match.calcMass(), match.massError(), match.autovalidated, match.validated, match.searchId, match.runName(), match.scanNumber, match.scanIndex, match.crossLinkerModMass(), match.fragmentToleranceString(), match.ionTypesString(), decoy1, decoy2, distancesJoined.join('","')
+			];
+            csv += '"' + data.join('","') + '"\r\n';
+		/*
         }
     }
+	*/
+	});
+	
+	//console.log ("MCSV", count, matchMap.values().length);
     return csv;
 }
 
@@ -183,8 +203,14 @@ function getLinksCSV(){
     console.log ("searchIds", searchIds);
     var headerRow = '"' + headerArray.join('","') + '"';
 
+	/*
+	// filtered crosslinks already cached and obtainable via CLMSUI.compositeModelInst.getFilteredCrossLinks ("all");
     var crossLinks = CLMS.arrayFromMapValues(CLMSUI.compositeModelInst.get("clmsModel").get("crossLinks"));
     crossLinks = crossLinks.filter (function (crossLink) { return crossLink.filteredMatches_pp.length > 0; });
+	*/
+	var crossLinks = CLMSUI.compositeModelInst.getFilteredCrossLinks ("all");
+	//console.log ("XLINK COMP", crossLinks.length, crossLinks2.length);
+	
     var physicalDistances = CLMSUI.compositeModelInst.getCrossLinkDistances (crossLinks, {includeUndefineds: true, returnChainInfo: true, calcDecoyProteinDistances: true});
     //console.log ("pd", physicalDistances);
     var distance2dp = d3.format(".2f");
@@ -242,34 +268,30 @@ function getResidueCount() {
     var residueCounts = d3.map();
     var residuePairCounts = d3.map();
 
-    var crossLinksArray = CLMS.arrayFromMapValues(CLMSUI.compositeModelInst.get("clmsModel").get("crossLinks"));
-    var crossLinkCount = crossLinksArray.length;
-    for (var cl = 0; cl < crossLinkCount; cl++){
-		var residueLink = crossLinksArray[cl];
-        if (residueLink.filteredMatches_pp.length > 0){
+    //var crossLinks = CLMS.arrayFromMapValues(CLMSUI.compositeModelInst.get("clmsModel").get("crossLinks")); 
+	var crossLinks = CLMSUI.compositeModelInst.getFilteredCrossLinks ("all");	// already pre-filtered
+    crossLinks.forEach (function (residueLink) {
+		var linkedRes1 = residueLink.fromProtein.sequence[residueLink.fromResidue - 1];
+		if (!linkedRes1) { linkedRes1 = ""}
+		var linkedRes2 = residueLink.isLinearLink() ? "" : residueLink.toProtein.sequence[residueLink.toResidue - 1];
+		incrementCount(linkedRes1);
+		incrementCount(linkedRes2);
 
-            var linkedRes1 = residueLink.fromProtein.sequence[residueLink.fromResidue - 1];
-            if (!linkedRes1) { linkedRes1 = ""}
-            var linkedRes2 = residueLink.isLinearLink() ? "" : residueLink.toProtein.sequence[residueLink.toResidue - 1];
-            incrementCount(linkedRes1);
-            incrementCount(linkedRes2);
+		var pairId;
+		if (linkedRes1 > linkedRes2) {
+			pairId = linkedRes2 + "-" + linkedRes1;
+		} else {
+			pairId = linkedRes1 + "-" + linkedRes2;
+		}
 
-            var pairId;
-            if (linkedRes1 > linkedRes2) {
-                pairId = linkedRes2 + "-" + linkedRes1;
-            } else {
-                pairId = linkedRes1 + "-" + linkedRes2;
-            }
-
-            var c = parseInt(residuePairCounts.get(pairId));
-            if (isNaN(c)){
-                residuePairCounts.set(pairId, 1);
-            }else {
-                c++;
-                residuePairCounts.set(pairId, c);
-            }
-        }
-    }
+		var c = parseInt(residuePairCounts.get(pairId));
+		if (isNaN(c)){
+			residuePairCounts.set(pairId, 1);
+		}else {
+			c++;
+			residuePairCounts.set(pairId, c);
+		}
+    });
 
     residuePairCounts.forEach(function (k,v){
         csv += '"' + k + '","'

--- a/js/filterModel.js
+++ b/js/filterModel.js
@@ -21,7 +21,7 @@ CLMSUI.BackboneModelTypes = _.extend(CLMSUI.BackboneModelTypes || {},
                 B: true,
                 C: true,
                 Q: true,
-                unval: true,
+                unval: false,
                 AUTO: false,
                 decoys: true,
                 //fdr
@@ -38,9 +38,9 @@ CLMSUI.BackboneModelTypes = _.extend(CLMSUI.BackboneModelTypes || {},
             },
 
             initialize: function (options, secondarySettings) {
-                // ^^^setting an array in defaults passes that same array reference to every instantiated model, so do it in initialize
                 if (!this.get("matchScoreCutoff")) {
                     this.set("matchScoreCutoff", [0, 100]);
+					// ^^^setting an array in defaults passes that same array reference to every instantiated model, so do it in initialize
                 }
                 // scoreExtent used to restrain text input values
                 this.scoreExtent = (secondarySettings ? secondarySettings.scoreExtent : undefined) || this.get("matchScoreCutoff").slice(0);
@@ -48,7 +48,16 @@ CLMSUI.BackboneModelTypes = _.extend(CLMSUI.BackboneModelTypes || {},
                 this.valMap = d3.map();
                 this.valMap.set("?", "Q");
                 this.textSet = d3.map();
+				
+				this.resetValues = this.toJSON();	// Store copy of original values if needed to restore later
             },
+			
+			resetFilter: function () {
+				this
+					.clear ({silent:true})
+					.set (this.resetValues)
+				;
+			},
 
             processTextFilters: function () {
                 var protSplit1 = this.get("protNames").toLowerCase().split(","); // split by commas

--- a/js/filterViewBB.js
+++ b/js/filterViewBB.js
@@ -16,6 +16,7 @@ CLMSUI.FilterViewBB = Backbone.View.extend({
         "click input.subsetToggleFilterToggle": "subsetToggleFilter",
         "keyup input.subsetNumberFilter": "subsetNumberFilter",
         "mouseup input.subsetNumberFilter": "subsetNumberFilter",
+		"dblclick button.filterReset": function() { this.model.resetFilter(); },
     },
 
     initialize: function (viewOptions) {
@@ -62,199 +63,238 @@ CLMSUI.FilterViewBB = Backbone.View.extend({
 
         // this.el is the dom element this should be getting added to, replaces targetDiv
         var mainDivSel = d3.select(this.el);
+		
+		
+		function initResetGroup () {
+			var resetDivSel = mainDivSel.append("div").attr ("class", "filterControlGroup verticalFlexContainer");
+			resetDivSel.append("p").attr("class", "smallHeading").text("Filter Bar");
+			resetDivSel.append("button")
+				.attr("class", "filterReset btn btn-1a btn-tight")
+				.attr("title", "Double-click to reset filter to originally set values")
+				.text("Reset")
+			;
+		}
 
-        var modeDivSel = mainDivSel.append("div").attr ("class", "filterControlGroup")
-									.attr ("id", "filterModeDiv");
-        //~ modeDivSel.append("span").attr("class", "sideOn").text("MODE");
-        var modeElems = modeDivSel.selectAll("div.modeToggles")
-            .data(this.options.modes, function(d) { return d.id; })
-            .enter()
-            .append ("div")
-            .attr ("class", "toggles")
-            .attr("id", function(d) { return "toggles_" + d.id; })
-            .attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
-            .append ("label")
-        ;
-        modeElems.append ("span")
-            .text (function(d) { return d.label; })
-        ;
-        modeElems.append ("input")
-            .attr ("id", function(d) { return d.id; })
-            .attr ("class", "modeToggle")
-            .attr ("name", "modeSelect")
-            .attr ("type", "radio")
-            .property ("checked", function(d) { return Boolean (self.model.get(d.id)); })
-        ;
-
-
-		var dataSubsetDivSel = mainDivSel.append("div").attr ("class", "filterControlGroup");
-        var subsetToggles = dataSubsetDivSel.selectAll("div.subsetToggles")
-            .data(this.options.subsetToggles, function(d) { return d.id; })
-            .enter()
-            .append ("div")
-            .attr ("class", "toggles subsetToggles")
-            .attr("id", function(d) { return "toggles_" + d.id; })
-            .attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
-            .append ("label")
-        ;
-        subsetToggles.append ("span")
-            .text (function(d) { return d.label; })
-        ;
-        subsetToggles.append ("input")
-            .attr ("id", function(d) { return d.id; })
-            .attr ("class", "subsetToggleFilterToggle")
-            .attr ("type", "checkbox")
-            .property ("checked", function(d) { return Boolean (self.model.get(d.id)); })
-        ;
+		
+		function initFilterModeGroup() {
+			var modeDivSel = mainDivSel.append("div").attr ("class", "filterControlGroup")
+										.attr ("id", "filterModeDiv");
+			//~ modeDivSel.append("span").attr("class", "sideOn").text("MODE");
+			var modeElems = modeDivSel.selectAll("div.modeToggles")
+				.data(this.options.modes, function(d) { return d.id; })
+				.enter()
+				.append ("div")
+				.attr ("class", "toggles")
+				.attr("id", function(d) { return "toggles_" + d.id; })
+				.attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
+				.append ("label")
+			;
+			modeElems.append ("span")
+				.text (function(d) { return d.label; })
+			;
+			modeElems.append ("input")
+				.attr ("id", function(d) { return d.id; })
+				.attr ("class", "modeToggle")
+				.attr ("name", "modeSelect")
+				.attr ("type", "radio")
+				.property ("checked", function(d) { return Boolean (self.model.get(d.id)); })
+			;
+		}
 
 
-        var subsetNumberFilters = dataSubsetDivSel.selectAll("div.subsetNumberFilterDiv")
-            .data(this.options.subsetNumberFilters, function(d) { return d.id; })
-            .enter()
-            .append ("div")
-            .attr ("class", "toggles subsetNumberFilterDiv")
-            //.attr("id", function(d) { return "toggles_" + d.id; }) // not a toggle, change id?
-            .attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
-            .append ("label")
-        ;
-        subsetNumberFilters.append ("span")
-            .text (function(d) { return d.label; })
-        ;
+		function initLinkPropertyGroup () {
+			var dataSubsetDivSel = mainDivSel.append("div").attr ("class", "filterControlGroup");
+			var subsetToggles = dataSubsetDivSel.selectAll("div.subsetToggles")
+				.data(this.options.subsetToggles, function(d) { return d.id; })
+				.enter()
+				.append ("div")
+				.attr ("class", "toggles subsetToggles")
+				.attr("id", function(d) { return "toggles_" + d.id; })
+				.attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
+				.append ("label")
+			;
+			subsetToggles.append ("span")
+				.text (function(d) { return d.label; })
+			;
+			subsetToggles.append ("input")
+				.attr ("id", function(d) { return d.id; })
+				.attr ("class", "subsetToggleFilterToggle")
+				.attr ("type", "checkbox")
+				.property ("checked", function(d) { return Boolean (self.model.get(d.id)); })
+			;
 
-        subsetNumberFilters.append("p").classed("cutoffLabel",true).append("span").html("&ge;");
+			var subsetNumberFilters = dataSubsetDivSel.selectAll("div.subsetNumberFilterDiv")
+				.data(this.options.subsetNumberFilters, function(d) { return d.id; })
+				.enter()
+				.append ("div")
+				.attr ("class", "toggles subsetNumberFilterDiv")
+				//.attr("id", function(d) { return "toggles_" + d.id; }) // not a toggle, change id?
+				.attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
+				.append ("label")
+			;
+			subsetNumberFilters.append ("span")
+				.text (function(d) { return d.label; })
+			;
 
-        subsetNumberFilters.append ("input")
-            .attr ({id: function(d) { return d.id; }, class: "subsetNumberFilter", type: "number",
-						min: function(d) { return d.min; }, max: function(d) { return d.max; }})
-            .property ("value", function(d) { return self.model.get(d.id); })
-        ;
+			subsetNumberFilters.append("p").classed("cutoffLabel",true).append("span").html("&ge;");
+
+			subsetNumberFilters.append ("input")
+				.attr ({id: function(d) { return d.id; }, class: "subsetNumberFilter", type: "number",
+							min: function(d) { return d.min; }, max: function(d) { return d.max; }})
+				.property ("value", function(d) { return self.model.get(d.id); })
+			;
+		}
 
 
-		var validationDivSel = mainDivSel.append("div")
-								.attr ("class", "filterControlGroup")
-								.attr ("id", "validationStatus");
-        var validationElems = validationDivSel.selectAll("div.validationToggles")
-            .data(this.options.validationStatusToggles, function(d) { return d.id; })
-            .enter()
-            .append ("div")
-            .attr ("class", "toggles validationToggles")
-            .attr("id", function(d) { return "toggles_" + d.id; })
-            .attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
-            .append ("label")
-        ;
+		function initValidationGroup () {
+			var validationDivSel = mainDivSel.append("div")
+									.attr ("class", "filterControlGroup")
+									.attr ("id", "validationStatus");
+			var validationElems = validationDivSel.selectAll("div.validationToggles")
+				.data(this.options.validationStatusToggles, function(d) { return d.id; })
+				.enter()
+				.append ("div")
+				.attr ("class", "toggles validationToggles")
+				.attr("id", function(d) { return "toggles_" + d.id; })
+				.attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
+				.append ("label")
+			;
 
-        validationElems.append ("span")
-            .text (function(d) { return d.label; })
-        ;
+			validationElems.append ("span")
+				.text (function(d) { return d.label; })
+			;
 
-        validationElems.append ("input")
-            .attr ("id", function(d) { return d.id; })
-            .attr ("class", function(d) { return d.special ? "subsetToggleFilterToggle" : "filterTypeToggle"; })
-            .attr ("type", "checkbox")
-            .property ("checked", function(d) { return Boolean (self.model.get(d.id)); })
-        ;
+			validationElems.append ("input")
+				.attr ("id", function(d) { return d.id; })
+				.attr ("class", function(d) { return d.special ? "subsetToggleFilterToggle" : "filterTypeToggle"; })
+				.attr ("type", "checkbox")
+				.property ("checked", function(d) { return Boolean (self.model.get(d.id)); })
+			;
+		}
 
-		var cutoffDivSel = mainDivSel.append ("div")
-								.attr("class", "filterControlGroup")
-								.attr("id", "matchScore");
-		      //~ cutoffDivSel.append("span").attr("class", "sideOn").text("CUTOFF");
+		
+		function initScoreFilterGroup () {
+			var cutoffDivSel = mainDivSel.append ("div")
+									.attr("class", "filterControlGroup")
+									.attr("id", "matchScore");
+				  //~ cutoffDivSel.append("span").attr("class", "sideOn").text("CUTOFF");
 
-        var sliderSection = cutoffDivSel.append ("div").attr("class", "scoreSlider");
-        // Can validate template output at http://validator.w3.org/#validate_by_input+with_options
-        var tpl = _.template ("<div><p>Match score</p><P class='vmin cutoffLabel'><span>&gt;</span></P><P>Min</P></div><div id='<%= eid %>'></div><div><p>Match score</p><P class='cutoffLabel vmax'><span>&lt;</span></P><P>Max</P></div>");
-        sliderSection.html (tpl ({eid: self.el.id+"SliderHolder"}));
-		// sliderSection.style('display', (self.model.get("scores") === null) ? 'none' : null);
-        sliderSection.selectAll("p.cutoffLabel")
-            .attr ("title", function () {
-                var isMinInput = d3.select(this).classed("vmin");
-                return "Filter out matches with scores "+(isMinInput ? "less than": "greater than")+" X e.g. "+(isMinInput ? "8.0": "20.0");
-            })
-            .append("input")
-            .attr({
-                type: "number",
-                step: 0.1,
-                //min: 0,
-            })
-			.property ("value", function () {
-				var isMinInput = d3.select(this.parentNode).classed("vmin");
-				var cutoff = self.model.get("matchScoreCutoff");
-				var val = cutoff [isMinInput ? 0 : 1];
-				return val !== undefined ? val : "";
-			})
-            .on ("change", function() { // "input" activates per keypress which knackers typing in anything >1 digit
-                //console.log ("model", self.model);
-                var val = +this.value;
-                var isMinInput = d3.select(this.parentNode).classed("vmin");
-                var cutoff = self.model.get("matchScoreCutoff");
-                var scoreExtent = self.model.scoreExtent;
-                // take new values, along with score extents, sort them and discard extremes for new cutoff settings
-                var newVals = [isMinInput ? val : (cutoff[0] !== undefined ? cutoff[0] : scoreExtent[0]),
-							   isMinInput ? (cutoff[1] !== undefined ? cutoff[1] : scoreExtent[1]) : val,
-							   scoreExtent[0], scoreExtent[1]]
-					.filter (function (v) { return v !== undefined; })
-                    .sort(function(a,b) { return a - b;})
-				;
-				//console.log ("newVals", newVals);
-				newVals = newVals.slice ((newVals.length / 2) - 1, (newVals.length / 2) + 1);
+			var sliderSection = cutoffDivSel.append ("div").attr("class", "scoreSlider");
+			// Can validate template output at http://validator.w3.org/#validate_by_input+with_options
+			var tpl = _.template ("<div><p>Match score</p><P class='vmin cutoffLabel'><span>&gt;</span></P><P>Min</P></div><div id='<%= eid %>'></div><div><p>Match score</p><P class='cutoffLabel vmax'><span>&lt;</span></P><P>Max</P></div>");
+			sliderSection.html (tpl ({eid: self.el.id+"SliderHolder"}));
+			// sliderSection.style('display', (self.model.get("scores") === null) ? 'none' : null);
+			sliderSection.selectAll("p.cutoffLabel")
+				.attr ("title", function () {
+					var isMinInput = d3.select(this).classed("vmin");
+					return "Filter out matches with scores "+(isMinInput ? "less than": "greater than")+" X e.g. "+(isMinInput ? "8.0": "20.0");
+				})
+				.append("input")
+				.attr({
+					type: "number",
+					step: 0.1,
+					//min: 0,
+				})
+				.property ("value", function () {
+					var isMinInput = d3.select(this.parentNode).classed("vmin");
+					var cutoff = self.model.get("matchScoreCutoff");
+					var val = cutoff [isMinInput ? 0 : 1];
+					return val !== undefined ? val : "";
+				})
+				.on ("change", function() { // "input" activates per keypress which knackers typing in anything >1 digit
+					//console.log ("model", self.model);
+					var val = +this.value;
+					var isMinInput = d3.select(this.parentNode).classed("vmin");
+					var cutoff = self.model.get("matchScoreCutoff");
+					var scoreExtent = self.model.scoreExtent;
+					// take new values, along with score extents, sort them and discard extremes for new cutoff settings
+					var newVals = [isMinInput ? val : (cutoff[0] !== undefined ? cutoff[0] : scoreExtent[0]),
+								   isMinInput ? (cutoff[1] !== undefined ? cutoff[1] : scoreExtent[1]) : val,
+								   scoreExtent[0], scoreExtent[1]]
+						.filter (function (v) { return v !== undefined; })
+						.sort(function(a,b) { return a - b;})
+					;
+					//console.log ("newVals", newVals);
+					newVals = newVals.slice ((newVals.length / 2) - 1, (newVals.length / 2) + 1);
 
-                self.model.set("matchScoreCutoff", newVals);
-            })
-        ;
+					self.model.set("matchScoreCutoff", newVals);
+				})
+			;
+		}
 
-		//following may not be best practice, its here to get the placeholder divs in the right place in the filter div (the grey bar at bottom)
-        mainDivSel.append ("div")
-            .attr("class", "filterControlGroup")
-            .attr("id", "fdrPanel")
-        ;
+		
+		function initFDRPlaceholder() {
+			//following may not be best practice, its here to get the placeholder divs in the right place in the filter div (the grey bar at bottom)
+			mainDivSel.append ("div")
+				.attr("class", "filterControlGroup")
+				.attr("id", "fdrPanel")
+			;
+		}
+		
 
-        var navDivSel = mainDivSel.append ("div")
-            .attr("class", "filterControlGroup")
-            .attr("id", "navFilters")
-		;
-		//~ navDivSel.append("span").attr("class", "sideOn").text("NAVIGATION");
+		function initNavigationGroup () {
+			var navDivSel = mainDivSel.append ("div")
+				.attr("class", "filterControlGroup")
+				.attr("id", "navFilters")
+			;
+			//~ navDivSel.append("span").attr("class", "sideOn").text("NAVIGATION");
 
-		var textFilters = navDivSel.selectAll("div.textFilters")
-            .data(this.options.navigationFilters, function(d) { return d.id; })
-            .enter()
-            .append("div")
-            .attr("class", "textFilters")
-            .attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
-            .append ("label")
-        ;
-        textFilters.append("span")
-            .text (function(d) { return d.label; })
-        ;
-        textFilters.append ("input")
-            .attr ("id", function(d) { return d.id; })
-            .attr ("class", "filterTypeText")
-            .attr ("type", "textbox")
-            .attr ("size", function(d) { return d.chars; })
-			.property ("value", function(d) { return self.model.get(d.id); })
-        ;
+			var textFilters = navDivSel.selectAll("div.textFilters")
+				.data(this.options.navigationFilters, function(d) { return d.id; })
+				.enter()
+				.append("div")
+				.attr("class", "textFilters")
+				.attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
+				.append ("label")
+			;
+			textFilters.append("span")
+				.text (function(d) { return d.label; })
+			;
+			textFilters.append ("input")
+				.attr ("id", function(d) { return d.id; })
+				.attr ("class", "filterTypeText")
+				.attr ("type", "textbox")
+				.attr ("size", function(d) { return d.chars; })
+				.property ("value", function(d) { return self.model.get(d.id); })
+			;
+		}
+		
+		
+		function initNavigationGroup2 () {
+			var navNumberDivSel = mainDivSel.append ("div")
+				.attr("class", "filterControlGroup")
+				.attr("id", "navNumberFilters")
+			;
+			var navigationNumberFilters = navNumberDivSel.selectAll("div.navNumberFilterDiv")
+				.data(this.options.navigationNumberFilters, function(d) { return d.id; })
+				.enter()
+				.append ("div")
+				.attr ("class", "navNumberFilterDiv")
+				.attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
+				.append ("label")
+			;
+			navigationNumberFilters.append ("span")
+				.style("display", "block")
+				.text (function(d) { return d.label; })
+			;
+			navigationNumberFilters.append("p").classed("cutoffLabel",true).append("span").html ("&ge;");
+			navigationNumberFilters.append ("input")
+				.attr ({id: function(d) { return d.id; }, class: "subsetNumberFilter", type: "number",
+							min: function(d) { return d.min; }, max: function(d) { return d.max; }})
+				.property ("value", function(d) { return self.model.get(d.id); })
+			;
+		}
 
-        var navNumberDivSel = mainDivSel.append ("div")
-            .attr("class", "filterControlGroup")
-            .attr("id", "navNumberFilters")
-		;
-        var navigationNumberFilters = navNumberDivSel.selectAll("div.navNumberFilterDiv")
-            .data(this.options.navigationNumberFilters, function(d) { return d.id; })
-            .enter()
-            .append ("div")
-            .attr ("class", "navNumberFilterDiv")
-            .attr ("title", function(d) { return d.tooltip ? d.tooltip : undefined; })
-            .append ("label")
-        ;
-        navigationNumberFilters.append ("span")
-            .style("display", "block")
-            .text (function(d) { return d.label; })
-        ;
-        navigationNumberFilters.append("p").classed("cutoffLabel",true).append("span").html ("&ge;");
-        navigationNumberFilters.append ("input")
-            .attr ({id: function(d) { return d.id; }, class: "subsetNumberFilter", type: "number",
-                        min: function(d) { return d.min; }, max: function(d) { return d.max; }})
-            .property ("value", function(d) { return self.model.get(d.id); })
-        ;
-
+		initResetGroup.call (this);
+		initFilterModeGroup.call (this);
+		initLinkPropertyGroup.call (this);
+		initValidationGroup.call (this);
+		initScoreFilterGroup.call (this);
+		initFDRPlaceholder.call (this);
+		initNavigationGroup.call (this);
+		initNavigationGroup2.call (this);
+		
+		this.setInputValuesFromModel (this.model);
 
 
         // hide toggle options if no point in them being there (i.e. no between / self link toggle if only 1 protein)
@@ -270,15 +310,14 @@ CLMSUI.FilterViewBB = Backbone.View.extend({
 
         this.displayEventName = viewOptions.displayEventName;
 
-        this.listenTo (this.model, "change:matchScoreCutoff", function(model, val) {
-            //console.log ("cutoff", val);
+        this.listenTo (this.model, "change:matchScoreCutoff", function (model, val) {
             mainDivSel.select(".vmin input").property("value", val[0]); // min label
             mainDivSel.select(".vmax input").property("value", val[1]); // max label
         });
-        //todo: extend to update all attributes
-        this.listenTo (this.model, "change:unval", function  (model, val) {
-			mainDivSel.select("#unval").property("checked", Boolean (val));
-		});
+
+		this.listenTo (this.model, "change", function (model) {
+			this.setInputValuesFromModel (model);
+		})
 
         mainDivSel.selectAll(".filterControlGroup").classed("noBreak", true);
 
@@ -286,18 +325,15 @@ CLMSUI.FilterViewBB = Backbone.View.extend({
     },
 
     filter: function (evt) {
-        //console.log ("this filterBB filter", evt);
         var target = evt.target;
-        var id = target.id;
-        console.log ("filter set", id, target.checked);
-        this.model.set (id, target.checked);
+        console.log ("filter set", target.id, target.checked);
+        this.model.set (target.id, target.checked);
     },
 
     textFilter: function (evt) {
         var target = evt.target;
-        var id = target.id;
-        console.log ("filter set", id, target.value);
-        this.model.set (id, target.value);
+        console.log ("filter set", target.id, target.value);
+        this.model.set (target.id, target.value);
     },
 
     subsetToggleFilter: function (evt) {
@@ -324,17 +360,32 @@ CLMSUI.FilterViewBB = Backbone.View.extend({
 
     modeChanged: function () {
 		var fdrMode = d3.select("#fdrMode").node().checked;
-        d3.selectAll("#validationStatus,#matchScore").style("display", fdrMode ? "none" : "inline-block");
-        d3.selectAll("#fdrPanel").style("display", fdrMode ? "inline-block" : "none");
-        if (fdrMode == true) {
-            d3.select("#ambig").property("checked", false);
-            d3.select("#ambig").property("disabled", true);
-            this.model.set("ambig", false);
-        } else {
-            d3.select("#ambig").property("disabled", false);
-        }
 		this.model.set ("fdrMode", fdrMode);
     },
+	
+	setInputValuesFromModel: function () {
+		var model = this.model;
+		var mainDiv = d3.select(this.el);
+		
+		mainDiv.selectAll("input.filterTypeText, input.subsetNumberFilter")
+			.property ("value", function(d) { return model.get(d.id); })
+		;
+		
+		mainDiv.selectAll("input.subsetToggleFilterToggle, input.modeToggle, input.filterTypeToggle")
+			.property ("checked", function (d) { return Boolean (model.get(d.id)); })
+		;
+		
+		// hide parts of the filter panel if mode (manual/fdr) setting has changed
+		if (model.changed.manualMode !== undefined || model.changed.fdrMode !== undefined) {
+			var fdrMode = model.get("fdrMode");
+			d3.selectAll("#validationStatus, #matchScore").style("display", fdrMode ? "none" : null);
+			d3.selectAll("#fdrPanel").style("display", fdrMode ? null : "none");
+			if (fdrMode == true) {
+				this.model.set("ambig", false);
+			}
+			d3.select("#ambig").property("disabled", fdrMode == true);
+		}
+	},
 
     render: function () {
         return this;
@@ -346,8 +397,7 @@ CLMSUI.FDRViewBB = Backbone.View.extend  ({
     initialize: function () {
 
         var chartDiv = d3.select(this.el);
-        //var tpl = _.template (("<div class=\"fdrCalculation\"><p>Basic link-level FDR calculation</p><span></span></div>");
-        chartDiv.html ("<div class=\"fdrCalculation\"><p>Basic link-level FDR calculation</p><span></span></div>");
+        chartDiv.html ("<div class='fdrCalculation'><p>Basic link-level FDR calculation</p><span></span></div>");
         var self = this;
         var options = [0.01, 0.05, 0.1, 0.2, 0.5/*, undefined*/];
         var labelFunc = function (d) { return d === undefined ? "Off" : d3.format("%")(d); };
@@ -363,9 +413,7 @@ CLMSUI.FDRViewBB = Backbone.View.extend  ({
                     .attr("type", "radio")
                     .attr("value", function(d) { return d; })
                     .attr("name", "fdrPercent")
-                    .property("checked", function(d) { return d === self.model.get("fdrThreshold"); })
                     .on ("click", function(d) {
-                        d3.select(self.el).select("input[type='number']").property("value", d * 100 /*""*/);
                         self.model.set("fdrThreshold", d);
                     })
         ;
@@ -381,15 +429,24 @@ CLMSUI.FDRViewBB = Backbone.View.extend  ({
                     .attr("min", 0)
                     .attr("max", 100)
                     .attr("step", 1)
-					.property ("value", self.model.get("fdrThreshold") * 100)
+					.attr ("class", "fdrValue")
                     .on ("change", function() { // "input" activates per keypress which knackers typing in anything >1 digit
-                        d3.select(self.el).selectAll("input[name='fdrPercent']").property("checked", false);
                         self.model.set("fdrThreshold", (+this.value) / 100);
                     })
         ;
+		
+		this.setInputValuesFromModel (this.model);
+		this.listenTo (this.model, "change:fdrThreshold", this.setInputValuesFromModel);
 
         return this;
-    }
+    },
+	
+	setInputValuesFromModel: function (model) {
+		var fdrThreshold = model.get("fdrThreshold");
+		var d3el = d3.select(this.el);
+		d3el.selectAll("input[name='fdrPercent']").property("checked", function(d) { return d === fdrThreshold; });
+		d3el.selectAll(".fdrValue").property("value", function() { return fdrThreshold * 100; });
+	}
 });
 
 CLMSUI.FilterSummaryViewBB = Backbone.View.extend({

--- a/js/networkFrame.js
+++ b/js/networkFrame.js
@@ -242,9 +242,9 @@ CLMSUI.init.modelsEssential = function(options) {
         matchScoreCutoff: scoreExtentInstance.slice()
     };
     var urlFilterSettings = CLMSUI.BackboneModelTypes.FilterModel.prototype.getFilterUrlSettings(urlChunkMap);
-    filterSettings = _.extend(filterSettings, urlFilterSettings); // overwrite default settings with url settings
-    console.log("urlFilterSettings", urlFilterSettings, "progFilterSettings", filterSettings);
-    var filterModelInst = new CLMSUI.BackboneModelTypes.FilterModel(filterSettings, {
+    filterSettings = _.extend (filterSettings, urlFilterSettings);	// overwrite default settings with url settings
+    console.log ("urlFilterSettings", urlFilterSettings, "progFilterSettings", filterSettings);
+    var filterModelInst = new CLMSUI.BackboneModelTypes.FilterModel (filterSettings, {
         scoreExtent: scoreExtentInstance
     });
 
@@ -278,7 +278,7 @@ CLMSUI.init.views = function() {
     console.log("MODEL", compModel);
 
     //todo: only if there is validated {
-    compModel.get("filterModel").set("unval", false);
+    // compModel.get("filterModel").set("unval", false); // set to false in filter model defaults
 
     var windowIds = ["spectrumPanelWrapper", "spectrumSettingsWrapper", "keyPanel", "nglPanel", "distoPanel", "matrixPanel", "alignPanel", "circularPanel", "proteinInfoPanel", "pdbPanel", "csvPanel", "searchSummaryPanel", "linkMetaLoadPanel", "proteinMetaLoadPanel", "scatterplotPanel", "urlSearchBox", "listPanel"];
     // something funny happens if I do a data join and enter with d3 instead

--- a/js/scatterplotViewBB.js
+++ b/js/scatterplotViewBB.js
@@ -256,7 +256,7 @@
             selectList: ["X", "Y"], 
             optionList: options, 
 			keepOldOptions: keepOld || false,
-            selectLabelFunc: function (d) { return "Plot This Data Along ("+d+") Axis ►"; }, 
+            selectLabelFunc: function (d) { return "Plot This Data On The "+d+" Axis ►"; }, 
             optionLabelFunc: function (d) { return d.label; }, 
 			optionValueFunc: function (d) { return d.id; },
             changeFunc: function () { self.axisChosen().render(); },

--- a/js/selectionTableViewBB.js
+++ b/js/selectionTableViewBB.js
@@ -76,8 +76,8 @@ CLMSUI.SelectionTableViewBB = Backbone.View.extend({
             "calcMass": "Calc Mass",
             "massError": "Mass Error (ppm)",
             "precursorIntensity": "Intensity",
-            "elutionStart": "Elut.Start",
-            "elutionEnd": "Elut.End",
+            "elutionStart": "Elut. Start",
+            "elutionEnd": "Elut. End",
         };
 
         this.numberColumns = d3.set(["ambiguity", "score", "linkPos1", "linkPos2", "pepPos1", "pepPos2", "precursorCharge", "expMZ", "expMass", "calcMZ", "calcMass", "massError", "precursorItensity", ]);


### PR DESCRIPTION
1. Filter view now updates itself from filter model 
2. Which means I can add a "Filter Reset" button (suggestion by user)
3. Exports use cached lists of filtered cross-links rather than calculating filtering from scratch